### PR TITLE
I think cleaner to just leave `predicate_failure_response` off for tr…

### DIFF
--- a/medium_example_2/script.py
+++ b/medium_example_2/script.py
@@ -42,8 +42,7 @@ input_schema.add_foreign_key("survey","premium",["SSN","SSN"])
 input_schema.add_data_row_predicate(
 "survey",
 lambda row: row["Monthly Expenditure"] <= row["Income"],
-predicate_name = "Expense cannot be grater than income",
-predicate_failure_response = "Error Message")
+predicate_name = "Expense cannot be grater than income")
 
 
 # Beyond everything is same as in example_1


### PR DESCRIPTION
…uthy predicates

In general, the term "predicate" implies we are only concerned with the truthy/falsey status of the value returned by the function.  That is to say, a predicate function is one where we only check if like this
```
if predicate(row):
    # handle clean row
else:
  # handle dirty row
```

Thus by default the `predicate_failure_response` is "Boolean". This implies `find_data_row_failures` only cares about truthy/falsey.

The `predicate_failure_response="Error Message"` case is just there to allow the predicate function to convey more detailed information to  `find_data_row_failures` about why the predicate failed. That information is  conveyed through by `find_data_row_failures` so as to give a more detailed 
understanding of what went wrong. For example, for `PanDatFactory` then `find_data_row_failures` will add an "Error Message" column.

----

But beware - `predicate_failure_response="Error Message"` means that `find_data_row_failures` cannot use the following idiom
 
```
if predicate(row):
    # handle clean row
else:
  # handle dirty row
```

Why not? Because this idiom does not allow `predicate` to convey any information past truthy/falsey. So in this case, `find_data_row_failures` looks like this.

```
response = predicate(row)
if response == True:
   # handle clean row
else:
  # use response to populate the Error Message column we create
```

So your code works, but the Error Message column won't have any useful information. And its possible you'll mislead someone because your example would **not** work if your predicate function returned a truthy result  other than `True` to indicate a clean row (which is possible for the default).